### PR TITLE
Adds the UpdateHandler class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ cache: npm
 
 # Scripts to run to test application
 script:
+  # Running "npm test" in TravisCI will run all scripts in parallel so this is to force them
+  # to run in sequence
+  - npm run test:lint
+  - npm run test:unit

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "description": "JSON-based communication for JavaScript in Node.js",
   "repository": "https://github.com/NGCP/communication-js",
   "scripts": {
-    "test": "npm run test:lint",
+    "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint --ext .ts \".\"",
+    "test:unit": "mocha --require ts-node/register test/**/*.test.ts",
     "lint": "eslint --fix --ext .ts \".\"",
     "build": "tsc --project . --outDir lib --pretty"
   },
@@ -20,15 +21,20 @@
     "xbee-api": "^0.6.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.8",
+    "@types/mocha": "^7.0.1",
     "@types/msgpack-lite": "^0.1.7",
     "@types/serialport": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
+    "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-chai-friendly": "^0.5.0",
     "eslint-plugin-import": "^2.20.0",
+    "mocha": "^7.0.1",
+    "ts-node": "^8.6.2",
     "typescript": "^3.7.5"
   }
 }

--- a/src/UpdateHandler.ts
+++ b/src/UpdateHandler.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface Handler<T> {
+  /** Callback function when an event occurs. */
+  onEvent: (value: T, options?: object) => void;
+
+  /** Callback function to determine if event should be removed from handler. */
+  shouldRemove: (value: T, options?: object) => boolean;
+
+  /** Function to remove the handler. Pre-defined already in the UpdateHandler class. */
+  remove: () => void;
+
+  /** Timeout function when the handler expires. */
+  expiry?: NodeJS.Timeout;
+}
+
+/**
+ * Manages handlers for events. Each handler will have callbacks when these
+ * events occur as well as callbacks to determine if the handler should still exist after that
+ * event (so if it should keep looking out for that event).
+ */
+export default class UpdateHandler {
+  private handlers: { [key: string]: Handler<any>[] | undefined } = {};
+
+  /**
+   * Adds a new handler to check for a specific event.
+   *
+   * @param eventName Name of the event to look out for.
+   * @param onEvent Callback function when the handler sees event happening.
+   * @param shouldRemove Callback function to determine if handler should be removed.
+   * @param expirationTime Amount of time for the handler to expire.
+   * @returns The handler created. Normally never need to access the handler itself unless it
+   *          needs to be manually removed using the handler.remove() function.
+   */
+  public addHandler<T>(
+    eventName: string,
+    onEvent: (value: T, options?: object) => void,
+    shouldRemove: (value: T, options?: object) => boolean,
+    expirationTime?: number,
+  ): Handler<T> {
+    const handler: Handler<T> = {
+      onEvent,
+      shouldRemove,
+      remove: () => this.removeHandler(eventName, handler),
+    };
+
+    if (expirationTime !== undefined) {
+      handler.expiry = setTimeout(() => {
+        // Deletes the handler when it expires
+        const currentHandlers = this.handlers[eventName] || [];
+        this.handlers[eventName] = currentHandlers.filter(
+          (lis): boolean => lis !== handler,
+        );
+      }, expirationTime);
+    }
+
+    // Adds the handler to the list with the proper event name.
+    const currentHandlers = this.handlers[eventName] || [];
+    currentHandlers.push(handler);
+    this.handlers[eventName] = currentHandlers;
+
+    return handler;
+  }
+
+  /**
+   * Processes all the handlers associated with the specific event. If more than one handler is
+   * watching a specific event then more than one handler callback will be run from this.
+   *
+   * @param eventName Name of the event that occured.
+   * @param value Value associated with that event when it happened.
+   * @param options Extra information about the event.
+   */
+  public processEvent<T>(eventName: string, value: T, options?: object): void {
+    if (!this.handlers[eventName]) return;
+
+    const currentHandlers = this.handlers[eventName] as Handler<T>[];
+    this.handlers[eventName] = currentHandlers.filter((handler) => {
+      handler.onEvent(value, options);
+
+      const shouldRemoveHandler = handler.shouldRemove(value, options);
+      if (shouldRemoveHandler && handler.expiry) {
+        clearTimeout(handler.expiry);
+      }
+      return !shouldRemoveHandler;
+    });
+  }
+
+  /**
+   * Removes the handler. The provided name and handler must be the same as the ones used when
+   * creating the handler. Called from when the remove() function is called in a handler.
+   *
+   * @param eventName Name of the event handler is looking for.
+   * @param handler Instance of handler to remove.
+   */
+  private removeHandler<T>(eventName: string, handler: Handler<T>): void {
+    if (handler.expiry) {
+      clearTimeout(handler.expiry);
+    }
+
+    // Removes the handler from the event's list of handlers.
+    const currentHandlers = this.handlers[eventName] || [];
+    this.handlers[eventName] = currentHandlers.filter((h) => handler !== h);
+  }
+}

--- a/test/UpdateHandler.test.ts
+++ b/test/UpdateHandler.test.ts
@@ -1,0 +1,221 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+
+import UpdateHandler from '../src/UpdateHandler';
+
+let updateHandler: UpdateHandler;
+let counter: number;
+
+describe('UpdateHandler', () => {
+  describe('addHandler() & processEvent()', () => {
+    beforeEach(() => {
+      counter = 0;
+      updateHandler = new UpdateHandler();
+    });
+
+    it('should allow adding a handler for a simple one time event', () => {
+      updateHandler.addHandler<number>('status', (v) => {
+        if (v === 10) {
+          counter += 1;
+        }
+      }, (v) => v === 10);
+
+      expect(counter).to.equal(0);
+
+      // Event should run and remove itself (only runs once).
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(1);
+
+      // Since event not present, should do nothing.
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(1);
+    });
+
+    it('should not remove the handler if event does not happen', () => {
+      updateHandler.addHandler<number>('status', (v) => {
+        if (v === 10) {
+          counter += 1;
+        }
+      }, (v) => v === 10);
+
+      expect(counter).to.equal(0);
+
+      updateHandler.processEvent('nope', 10);
+      expect(counter).to.equal(0);
+
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(1);
+    });
+
+    it('should allow adding handlers for events that can be run, but not get removed immediately', () => {
+      updateHandler.addHandler<number>('status', () => { counter += 1; }, (v) => v === 10);
+
+      expect(counter).to.equal(0);
+
+      updateHandler.processEvent('status', 0);
+      expect(counter).to.equal(1);
+
+      updateHandler.processEvent('status', -100);
+      expect(counter).to.equal(2);
+
+      updateHandler.processEvent('status', 1);
+      expect(counter).to.equal(3);
+
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(4);
+
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(4);
+    });
+
+    it('should allow adding several handlers for events with different names', () => {
+      updateHandler.addHandler<number>('status', () => { counter += 1; }, (v) => v === 10);
+      updateHandler.addHandler<string>('job', () => { counter += 100; }, (v) => v === 'error');
+
+      expect(counter).to.equal(0);
+
+      updateHandler.processEvent('status', 0);
+      expect(counter).to.equal(1);
+
+      updateHandler.processEvent('job', -100);
+      expect(counter).to.equal(101);
+
+      updateHandler.processEvent('status', 1);
+      expect(counter).to.equal(102);
+
+      updateHandler.processEvent('job', 'error');
+      expect(counter).to.equal(202);
+
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(203);
+
+      updateHandler.processEvent('job', 'error');
+      expect(counter).to.equal(203);
+
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(203);
+    });
+
+    it('should allow adding several handlers for events with the same name', () => {
+      let counter2 = 0;
+
+      updateHandler.addHandler<number>('status', () => { counter += 1; }, (v) => v === 10);
+      updateHandler.addHandler<string>('status', () => { counter2 += 100; }, (v) => v === 'error');
+
+      expect(counter).to.equal(0);
+      expect(counter2).to.equal(0);
+
+      updateHandler.processEvent('status', 0);
+      expect(counter).to.equal(1);
+      expect(counter2).to.equal(100);
+
+      updateHandler.processEvent('status', 1);
+      expect(counter).to.equal(2);
+      expect(counter2).to.equal(200);
+
+      updateHandler.processEvent('status', 'error');
+      expect(counter).to.equal(3);
+      expect(counter2).to.equal(300);
+
+      updateHandler.processEvent('status', 'error');
+      expect(counter).to.equal(4);
+      expect(counter2).to.equal(300);
+
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(5);
+      expect(counter2).to.equal(300);
+
+      updateHandler.processEvent('status', 10);
+      expect(counter).to.equal(5);
+      expect(counter2).to.equal(300);
+    });
+
+    it('should allow for events to expire on their own after a certain amount of time', (done) => {
+      updateHandler.addHandler<number>('status', () => { counter += 1; }, (v) => v === 10, 25);
+
+      expect(counter).to.equal(0);
+
+      updateHandler.processEvent('status', 0);
+      expect(counter).to.equal(1);
+
+      updateHandler.processEvent('status', 0);
+      expect(counter).to.equal(2);
+
+      setTimeout(() => {
+        counter += 100;
+        expect(counter).to.equal(102);
+
+        // Handler has expired already so this event should not increment the counter
+        updateHandler.processEvent('status', 0);
+        expect(counter).to.equal(102);
+
+        done();
+      }, 50);
+    });
+
+    it('should allow for events to expire on their own after a certain amount of time, with more events for the same key', (done) => {
+      let counter2 = 0;
+
+      updateHandler.addHandler<number>('status', () => { counter += 1; }, (v) => v === 10, 25);
+      updateHandler.addHandler<string>('status', () => { counter2 += 1; }, (v) => v === 'error');
+
+      expect(counter).to.equal(0);
+      expect(counter2).to.equal(0);
+
+      updateHandler.processEvent('status', 0);
+      expect(counter).to.equal(1);
+      expect(counter2).to.equal(1);
+
+      updateHandler.processEvent('status', 0);
+      expect(counter).to.equal(2);
+      expect(counter2).to.equal(2);
+
+      setTimeout(() => {
+        counter += 100;
+        expect(counter).to.equal(102);
+        expect(counter2).to.equal(2);
+
+        updateHandler.processEvent('status', 0);
+        expect(counter).to.equal(102);
+        expect(counter2).to.equal(3);
+
+        done();
+      }, 50);
+    });
+  });
+
+  describe('removeHandler()', () => {
+    it('should allow the removal of the given handler', () => {
+      updateHandler = new UpdateHandler();
+      let statusCounter = 0;
+      let locationCounter = 0;
+
+      const statusHandler = updateHandler.addHandler<number>('status', (v) => { statusCounter += v; }, () => false);
+
+      const locationHandler = updateHandler.addHandler<number>('location', (v) => { locationCounter += v; }, () => false);
+
+      expect(statusCounter).to.equal(0);
+      expect(locationCounter).to.equal(0);
+
+      updateHandler.processEvent('status', 1);
+      updateHandler.processEvent('location', 1);
+
+      expect(statusCounter).to.equal(1);
+      expect(locationCounter).to.equal(1);
+
+      statusHandler.remove();
+      updateHandler.processEvent('status', 1);
+      updateHandler.processEvent('location', 1);
+
+      expect(statusCounter).to.equal(1);
+      expect(locationCounter).to.equal(2);
+
+      locationHandler.remove();
+      updateHandler.processEvent('status', 1);
+      updateHandler.processEvent('location', 1);
+
+      expect(statusCounter).to.equal(1);
+      expect(locationCounter).to.equal(2);
+    });
+  });
+});


### PR DESCRIPTION
This change adds the existing UpdateHandler class from GCS to be used
in the communications API. This class is remade to be easier to read
for newer developers.

This class is in charge of creating instances of "handlers" whose job
is to look for certain events and perform two callback functions:
one is to simply run and the other is to determine whether the handler
should continue existing after that event or not.

Testing with mocha and chai is implemented with this class.

*Note that I will bypass the approval requirement to speed up development time.*