### PR TITLE
Refactor .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,4 @@
-# Prevent newline problems between different systems
+# Prevent line-ending problems between different operating systems
 
 * text=auto
-*.sln text eol=lf
-*.c text
-*.h text
-
-*.png binary
-*.jpg binary
+*.txt text eol=lf


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because `.gitattributes` has extra unnecessary rules
for this repository. This repository wil not have .c, .h, .png, .jpg
files.

 ## What has changed to address the problem?

This change removes unnecessary extensions to the file as well as
changes affected .sln files to .txt to make file more generic. The
description on the top of the file also has been reworded for clarity.

 ## How was this change tested?

This change was tested with `npm test`.