### PR TITLE
Fix config export and update README

### DIFF
--- a/.remarkrc.yml
+++ b/.remarkrc.yml
@@ -1,0 +1,10 @@
+plugins:
+  # Use style guide preset
+  - remark-preset-lint-markdown-style-guide
+
+  # Added rules
+  - [lint-maximum-line-length, 100]
+  - [lint-rule-style, ----------------------------------------------------------------------------------------------------]
+  - [lint-definition-case, false]
+  - [lint-list-item-indent, tab-size]
+  - [lint-ordered-list-marker-value, ordered]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,25 @@
 
 ## Introduction
 
-NGCP's communication framework for JSON-based communication in JavaScript.
+NGCP's communication framework for JSON-based communication in Node.js JavaScript framework.
+
+## Quick start
+
+To use this package in your Node.js project, you will need to clone this repository in the same
+directory as your project, and create a dependency on it:
+
+```bash
+# from your project directory
+cd ..
+git clone https://github.com/NGCP/communication-js.git
+cd communication-js
+npm link
+cd ../your-project-name
+npm link communication-js
+```
+
+Whenever the code here is updated, you can simply run `git pull` in your local `communication-js`
+directory and the code will update.
 
 ## License
 

--- a/dist/Messenger.js
+++ b/dist/Messenger.js
@@ -10,9 +10,6 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -20,8 +17,11 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-var config_1 = __importDefault(require("./config/config"));
+var config = __importStar(require("./config/config"));
 var Message = __importStar(require("./types/message"));
 var UpdateHandler_1 = __importDefault(require("./UpdateHandler"));
 var XBee_1 = __importDefault(require("./XBee"));
@@ -145,10 +145,10 @@ var Messenger = /** @class */ (function () {
         var jsonMessage = __assign({ id: this.sendingMessageId, sid: this.vehicleId, tid: targetVehicleId, time: Date.now() }, message);
         this.sendingMessageId += 1;
         // Send message
-        if (config_1.default.vehicles[targetVehicleId] === undefined) {
+        if (config.vehicles[targetVehicleId] === undefined) {
             throw new Error('Provided target vehicle ID does not point to a valid vehicle');
         }
-        this.xbee.sendData(jsonMessage, config_1.default.vehicles[targetVehicleId].macAddress);
+        this.xbee.sendData(jsonMessage, config.vehicles[targetVehicleId].macAddress);
         if (Message.isAcknowledgementMessage(message)
             || Message.isConnectionAcknowledgementMessage(message)
             || Message.isBadMessage(message)) {
@@ -157,9 +157,9 @@ var Messenger = /** @class */ (function () {
         // Set interval to repeatedly send message until it is acknowledged
         this.sendingInterval.set(targetVehicleId, setInterval(function () {
             _this.xbee.sendData(jsonMessage, '');
-        }, config_1.default.messageSendRateMs));
+        }, config.messageSendRateMs));
         // Add handler to handle the event that this message is acknowledged
-        this.updateHandler.addHandler(Messenger.generateHash(targetVehicleId, jsonMessage.id), function (ackMessage) { return _this.processAcknowledgement(ackMessage.sid); }, function () { return true; }, config_1.default.disconnectionTimeMs, function () {
+        this.updateHandler.addHandler(Messenger.generateHash(targetVehicleId, jsonMessage.id), function (ackMessage) { return _this.processAcknowledgement(ackMessage.sid); }, function () { return true; }, config.disconnectionTimeMs, function () {
             if (_this.onVehicleDisconnect !== undefined) {
                 _this.onVehicleDisconnect(targetVehicleId);
             }

--- a/dist/config/config.d.ts
+++ b/dist/config/config.d.ts
@@ -1,18 +1,15 @@
-declare const _default: {
-    /** Amount of time before a vehicle disconnects if it receives no messages from the other */
-    disconnectionTimeMs: number;
-    /**
-     * Amount of time before a message that requires acknowledgement is sent again if it is not
-     * acknowledged
-     */
-    messageSendRateMs: number;
-    /** Map of vehicles' ID to their information */
-    vehicles: {
-        [key: number]: {
-            macAddress: string;
-            name: string;
-            type: "station" | "plane" | "rover";
-        };
+/** Amount of time before a vehicle disconnects if it receives no messages from the other */
+export declare const disconnectionTimeMs = 20000;
+/**
+ * Amount of time before a message that requires acknowledgement is sent again if it is not
+ * acknowledged
+ */
+export declare const messageSendRateMs = 10000;
+/** Map of vehicles' ID to their information */
+export declare const vehicles: {
+    [key: number]: {
+        macAddress: string;
+        name: string;
+        type: 'station' | 'plane' | 'rover';
     };
 };
-export default _default;

--- a/dist/config/config.js
+++ b/dist/config/config.js
@@ -1,8 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-var disconnectionTimeMs = 20000;
-var messageSendRateMs = 10000;
-var vehicles = {
+/** Amount of time before a vehicle disconnects if it receives no messages from the other */
+exports.disconnectionTimeMs = 20000;
+/**
+ * Amount of time before a message that requires acknowledgement is sent again if it is not
+ * acknowledged
+ */
+exports.messageSendRateMs = 10000;
+/** Map of vehicles' ID to their information */
+exports.vehicles = {
     0: {
         macAddress: '0013A2004194754E',
         name: 'GCS',
@@ -48,15 +54,4 @@ var vehicles = {
         name: 'Blimp',
         type: 'plane',
     },
-};
-exports.default = {
-    /** Amount of time before a vehicle disconnects if it receives no messages from the other */
-    disconnectionTimeMs: disconnectionTimeMs,
-    /**
-     * Amount of time before a message that requires acknowledgement is sent again if it is not
-     * acknowledged
-     */
-    messageSendRateMs: messageSendRateMs,
-    /** Map of vehicles' ID to their information */
-    vehicles: vehicles,
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "npm run test:lint && npm run test:unit && npm run build",
-    "test:lint": "eslint --ext .ts \".\"",
+    "test:lint": "eslint --ext .ts \".\" && remark .",
     "test:unit": "nyc mocha --require ts-node/register test/**/*.test.ts",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "build": "tsc"
@@ -35,6 +35,8 @@
     "eslint-plugin-import": "^2.20.0",
     "mocha": "^7.0.1",
     "nyc": "^15.0.0",
+    "remark-cli": "^7.0.1",
+    "remark-preset-lint-markdown-style-guide": "^2.1.3",
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "communication-js",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "author": "Northrop Grumman Collaboration Project",
   "description": "JSON-based communication for JavaScript in Node.js",
@@ -12,7 +12,7 @@
     "test:lint": "eslint --ext .ts \".\"",
     "test:unit": "nyc mocha --require ts-node/register test/**/*.test.ts",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "build": "tsc --project ."
+    "build": "tsc"
   },
   "dependencies": {
     "msgpack-lite": "^0.1.26",

--- a/src/Messenger.ts
+++ b/src/Messenger.ts
@@ -1,5 +1,5 @@
 import SerialPort from 'serialport';
-import config from './config/config';
+import * as config from './config/config';
 import * as Misc from './types/misc';
 import * as Message from './types/message';
 import * as Task from './types/task';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,7 +1,14 @@
-const disconnectionTimeMs = 20000;
-const messageSendRateMs = 10000;
+/** Amount of time before a vehicle disconnects if it receives no messages from the other */
+export const disconnectionTimeMs = 20000;
 
-const vehicles: {
+/**
+ * Amount of time before a message that requires acknowledgement is sent again if it is not
+ * acknowledged
+ */
+export const messageSendRateMs = 10000;
+
+/** Map of vehicles' ID to their information */
+export const vehicles: {
   [key: number]: { macAddress: string; name: string; type: 'station' | 'plane' | 'rover' };
 } = {
   0: {
@@ -49,17 +56,4 @@ const vehicles: {
     name: 'Blimp',
     type: 'plane',
   },
-};
-
-export default {
-  /** Amount of time before a vehicle disconnects if it receives no messages from the other */
-  disconnectionTimeMs,
-  /**
-   * Amount of time before a message that requires acknowledgement is sent again if it is not
-   * acknowledged
-   */
-  messageSendRateMs,
-
-  /** Map of vehicles' ID to their information */
-  vehicles,
 };


### PR DESCRIPTION
## Why is the change being made?

This change was made because there was a bug when importing this project and trying to use the `config` variable.

There was also a decision in how this project was to be deployed to be used by other projects in NGCP: locally. Doing it this way will prevent this package from being deployed to npm.

## What has changed to address the problem?

This change fixes the config bug by removing the `export default`. Alternatively, the `export default` could have been kept but `import * as config` could have been changed to `import config` in `src/index.ts`. I think the former is better.

This change also adds instructions on how to include this package on Node.js packages, as it is not installed through `npm install`, but through `npm link` (hence this package will not show up on your project's `package.json` file).

## How was this change tested?

This change was tested with `npm test`.

## Related documents, URLs, commits