### PR TITLE
Add webhooks for master builds to Discord

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,17 @@ language: node_js
 node_js:
   - lts/*
 
-# Cache node_modules after testing
-cache: npm
-
 # Scripts to run to test application
 script:
-  # Running "npm test" in TravisCI will run all scripts in parallel so this is to force them
-  # to run in sequence
-  - npm run test:lint
-  - npm run test:unit
+  - npm test
 
-# Run coverage after tests pass
-after_success: npm run coverage
+# Scripts to run after build success/failure
+after_success:
+  - npm run coverage
+  - wget https://raw.githubusercontent.com/NGCP/GCS/master/script/webhook.sh
+  - chmod +x webhook.sh
+  - ./webhook.sh success
+after_failure:
+  - wget https://raw.githubusercontent.com/NGCP/GCS/master/script/webhook.sh
+  - chmod +x webhook.sh
+  - ./webhook.sh failure


### PR DESCRIPTION
 ## Why is the change being made?

This change is made because it is important to put build status of the
`master` branch to Discord.

 ## What has changed to address the problem?

This change runs the webhooks script in `NGCP/GCS`. The script only
posts to the Discord channel if a build happens in `master` branch. The
`WEBHOOK_URL` has been set to the Discord webhook in Travis CI.

 ## How was this change tested?

This change was tested in a separate PR https://github.com/NGCP/GCS/pull/104

 ## Related documents, URLs, commits

_Note that I will bypass the approval requirement to speed up development time._